### PR TITLE
Explicit JSON encode to allow easing version constraints

### DIFF
--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -427,5 +427,5 @@ sendMail (ApiKey key) mail' = do
       opts = defaults &
           (header "Authorization" .~ [tkn])
         . (header "Content-Type" .~ ["application/json"])
-  r <- postWith opts (T.unpack sendGridAPI) (toJSON mail')
+  r <- postWith opts (T.unpack sendGridAPI) $ encode (toJSON mail')
   return $ r ^. responseStatus . statusCode


### PR DESCRIPTION
This tiny change enabled me to compile on base-4.8.1 and lens 4.13