### PR TITLE
Propagate HttpException and Response through sendMail return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A library for accessing the [v3 SendGrid API](https://sendgrid.com/docs/API_Refe
 
 import Data.List.NonEmpty (fromList)
 import Network.SendGridV3.Api
+import Control.Lens ((^.))
+import Network.Wreq (responseStatus, statusCode)
 
 sendGridApiKey :: ApiKey
 sendGridApiKey = ApiKey "SG..."
@@ -22,12 +24,11 @@ testMail =
 
 main :: IO ()
 main = do
-  -- Simple Send
-  statusCode <- sendMail sendGridApiKey testMail
-  print statusCode
-  -- Send with further options
-  statusCode' <- sendMail sendGridApiKey (testMail { _mailSendAt = Just 1516468000 })
-  print statusCode'
+  -- Send an email, overriding options as needed
+  eResponse <- sendMail sendGridApiKey (testMail { _mailSendAt = Just 1516468000 })
+  case eResponse of
+    Left httpException -> error $ show httpException
+    Right response -> print (response ^. responseStatus . statusCode)
 ```
 
 # Test Setup

--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -29,6 +29,8 @@ library
                      , semigroups >= 0.18
                      , text >= 1.2
                      , wreq >= 0.5
+                     , http-client
+                     , bytestring
   hs-source-dirs:      src
   default-language:    Haskell2010
 
@@ -42,8 +44,10 @@ test-suite test
   main-is:
     test.hs
   build-depends:  base >= 4 && < 5
+                , lens >= 4.13
                 , semigroups >= 0.18
                 , sendgrid-v3
                 , tasty >= 1.0
                 , tasty-hunit >= 0.10
                 , text >= 1.2
+                , wreq >= 0.5

--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -29,8 +29,8 @@ library
                      , semigroups >= 0.18
                      , text >= 1.2
                      , wreq >= 0.5
-                     , http-client
-                     , bytestring
+                     , http-client >= 0.5
+                     , bytestring >= 0.10.8
   hs-source-dirs:      src
   default-language:    Haskell2010
 

--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                sendgrid-v3
-version:             0.1.2.0
+version:             0.2.2.0
 synopsis:            Sendgrid v3 API library
 description:         SendGrid v3 Mail API client
 homepage:            https://github.com/marcelbuesing/sendgrid-v3

--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -6,13 +6,15 @@
 --
 -- >
 -- > {-# LANGUAGE OverloadedStrings #-}
--- > 
+-- >
 -- > import Data.List.NonEmpty (fromList)
 -- > import Network.SendGridV3.Api
--- > 
+-- > import Control.Lens ((^.))
+-- > import Network.Wreq (responseStatus, statusCode)
+-- >
 -- > sendGridApiKey :: ApiKey
 -- > sendGridApiKey = ApiKey "SG..."
--- > 
+-- >
 -- > testMail :: Mail () ()
 -- > testMail =
 -- >   let to = personalization $ fromList [MailAddress "john@example.com" "John Doe"]
@@ -20,15 +22,14 @@
 -- >       subject = "Email Subject"
 -- >       content = fromList [mailContentText "Example Content"]
 -- >   in mail [to] from subject content
--- > 
+-- >
 -- > main :: IO ()
 -- > main = do
--- >   -- Simple Send
--- >   statusCode <- sendMail sendGridApiKey testMail
--- >   print statusCode
--- >   -- Send with further options
--- >   statusCode' <- sendMail sendGridApiKey (testMail { _mailSendAt = Just 1516468000 })
--- >   print statusCode'
+-- >   -- Send an email, overriding options as needed
+-- >   eResponse <- sendMail sendGridApiKey (testMail { _mailSendAt = Just 1516468000 })
+-- >   case eResponse of
+-- >     Left httpException -> error $ show httpException
+-- >     Right response -> print (response ^. responseStatus . statusCode)
 --
 module Network.SendGridV3.Api where
 

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -6,6 +6,8 @@ import Network.SendGridV3.Api
 import System.Environment
 import Test.Tasty
 import Test.Tasty.HUnit
+import Control.Lens ((^.))
+import Network.Wreq
 
 testMail :: MailAddress -> Mail () ()
 testMail addr =
@@ -18,11 +20,15 @@ main = do
   defaultMain $ testGroup "SendGrid v3 API"
     [
       testCase "Send email simple" $ do
-        statusCode <- sendMail sendgridKey (testMail testMailAddr)
-        statusCode @?= 202
+        eResponse <- sendMail sendgridKey (testMail testMailAddr)
+        case eResponse of
+          Left err -> error "Failed to send simple email"
+          Right r -> r ^. responseStatus . statusCode @?= 202
     , testCase "Send email with opts" $ do
-        statusCode <- sendMail sendgridKey ((testMail testMailAddr) { _mailSendAt = Just 1516468000 })
-        statusCode @?= 202
+        eResponse <- sendMail sendgridKey ((testMail testMailAddr) { _mailSendAt = Just 1516468000 })
+        case eResponse of
+          Left err -> error "Failed to send email with opts"
+          Right r -> r ^. responseStatus . statusCode @?= 202
     ]
 
 getSendGridKey :: IO ApiKey


### PR DESCRIPTION
Changes the type of `sendMail` from:

```haskell
sendMail :: (ToJSON a, ToJSON b) => ApiKey -> Mail a b -> IO Int
```

to 

```haskell
sendMail
  :: (ToJSON a, ToJSON b)
  => ApiKey
  -> Mail a b
  -> IO (Either HttpException (Response ByteString))
```

This will grant more agency to users of this library to respond to unexpected `HttpException`s and specific response types. Since this is a breaking change, the `MAJOR` version of the library has been bumped.

Closes #6 