### PR TITLE
Fix JSON serialization of SendGrid payloads

### DIFF
--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                sendgrid-v3
-version:             0.2.2.0
+version:             0.2.2.1
 synopsis:            Sendgrid v3 API library
 description:         SendGrid v3 Mail API client
 homepage:            https://github.com/marcelbuesing/sendgrid-v3

--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -21,7 +21,7 @@ source-repository head
 
 library
   exposed-modules:     Network.SendGridV3.Api
-  -- other-modules:
+  other-modules:       Network.SendGridV3.JSON
   -- other-extensions:
   build-depends:       aeson >= 1.3.0
                      , base >=4.8 && < 4.13

--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -111,7 +111,7 @@ data Personalization = Personalization
   } deriving (Show, Eq)
 
 -- | Personalization smart constructor only asking for the mandatory fields
-personalization :: (NonEmpty MailAddress) -> Personalization
+personalization :: NonEmpty MailAddress -> Personalization
 personalization to =
   Personalization
   { _personalizationTo            = to
@@ -126,6 +126,7 @@ personalization to =
 
 $(deriveToJSON (defaultOptions
               { fieldLabelModifier = unPrefix "_personalization"
+              , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''Personalization)
 
 -- | The content-disposition of the attachment specifying how you would like the attachment to be displayed.
@@ -399,7 +400,7 @@ $(deriveToJSON (defaultOptions
               , constructorTagModifier = map toLower }) ''Mail)
 
 -- | Smart constructor for `Mail`, asking only for the mandatory `Mail` parameters.
-mail :: (ToJSON a, ToJSON b) => [Personalization] -> MailAddress -> T.Text -> (NonEmpty MailContent) -> Mail a b
+mail :: (ToJSON a, ToJSON b) => [Personalization] -> MailAddress -> T.Text -> NonEmpty MailContent -> Mail a b
 mail personalizations from subject content =
   Mail
   { _mailPersonalizations = personalizations

--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -45,13 +45,14 @@ import           Network.Wreq hiding (Options)
 import           Network.HTTP.Client (HttpException)
 import           Data.ByteString.Lazy (ByteString)
 import           Control.Exception (try)
+import           Network.SendGridV3.JSON (unPrefix)
 
 -- | URL to SendGrid Mail API
 sendGridAPI :: T.Text
 sendGridAPI = "https://api.sendgrid.com/v3/mail/send"
 
 -- | Bearer Token for the API
-data ApiKey = ApiKey { _apiKey :: T.Text } deriving (Show, Eq);
+data ApiKey = ApiKey { _apiKey :: T.Text } deriving (Show, Eq)
 
 data MailAddress = MailAddress
   { -- | EmailAddress e.g. john@doe.com
@@ -61,7 +62,7 @@ data MailAddress = MailAddress
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_mailAddress" :: String))
+              { fieldLabelModifier = unPrefix "_mailAddress"
               , constructorTagModifier = map toLower }) ''MailAddress)
 
 data MailContent = MailContent
@@ -80,7 +81,7 @@ mailContentHtml :: T.Text -> MailContent
 mailContentHtml html = MailContent "text/html" html
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_mailContent" :: String))
+              { fieldLabelModifier = unPrefix "_mailContent"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''MailContent)
 
@@ -124,7 +125,7 @@ personalization to =
   }
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_personalization" :: String))
+              { fieldLabelModifier = unPrefix "_personalization"
               , constructorTagModifier = map toLower }) ''Personalization)
 
 -- | The content-disposition of the attachment specifying how you would like the attachment to be displayed.
@@ -155,7 +156,7 @@ data MailAttachment = MailAttachment
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_mailAttachment" :: String))
+              { fieldLabelModifier = unPrefix "_mailAttachment"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''MailAttachment)
 
@@ -169,7 +170,7 @@ data Asm = Asm
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_asm" :: String))
+              { fieldLabelModifier = unPrefix "_asm"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''Asm)
 
@@ -183,7 +184,7 @@ data Bcc = Bcc
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_bcc" :: String))
+              { fieldLabelModifier = unPrefix "_bcc"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''Bcc)
 
@@ -196,7 +197,7 @@ data BypassListManagement = BypassListManagement
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_bypassListManagement" :: String))
+              { fieldLabelModifier = unPrefix "_bypassListManagement"
               , constructorTagModifier = map toLower }) ''BypassListManagement)
 
 -- | The default footer that you would like included on every email.
@@ -210,7 +211,7 @@ data Footer = Footer
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_footer" :: String))
+              { fieldLabelModifier = unPrefix "_footer"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''Footer)
 
@@ -221,7 +222,7 @@ data SandboxMode = SandboxMode
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_sandboxMode" :: String))
+              { fieldLabelModifier = unPrefix "_sandboxMode"
               , constructorTagModifier = map toLower }) ''SandboxMode)
 
 -- | This allows you to test the content of your email for spam.
@@ -236,7 +237,7 @@ data SpamCheck = SpamCheck
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_spamCheck" :: String))
+              { fieldLabelModifier = unPrefix "_spamCheck"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''SpamCheck)
 
@@ -249,7 +250,7 @@ data ClickTracking = ClickTracking
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_clickTracking" :: String))
+              { fieldLabelModifier = unPrefix "_clickTracking"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''ClickTracking)
 
@@ -263,7 +264,7 @@ data OpenTracking = OpenTracking
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_openTracking" :: String))
+              { fieldLabelModifier = unPrefix "_openTracking"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''OpenTracking)
 
@@ -280,7 +281,7 @@ data SubscriptionTracking = SubscriptionTracking
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_subscriptionTracking" :: String))
+              { fieldLabelModifier = unPrefix "_subscriptionTracking"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''SubscriptionTracking)
 
@@ -301,7 +302,7 @@ data Ganalytics = Ganalytics
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_ganalytics" :: String))
+              { fieldLabelModifier = unPrefix "_ganalytics"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''Ganalytics)
 
@@ -317,7 +318,7 @@ data TrackingSettings = TrackingSettings
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_trackingSettings" :: String))
+              { fieldLabelModifier = unPrefix "_trackingSettings"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''TrackingSettings)
 
@@ -338,7 +339,7 @@ data MailSettings = MailSettings
  } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_mailSettings" :: String))
+              { fieldLabelModifier = unPrefix "_mailSettings"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''MailSettings)
 
@@ -393,7 +394,7 @@ data Mail a b = Mail
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions
-              { fieldLabelModifier = drop (length ("_mail" :: String))
+              { fieldLabelModifier = unPrefix "_mail"
               , omitNothingFields = True
               , constructorTagModifier = map toLower }) ''Mail)
 

--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -102,7 +102,7 @@ data Personalization = Personalization
   -- | A collection of JSON key/value pairs allowing you to specify specific handling instructions for your email.
   , _personalizationHeaders       :: Maybe [(T.Text, T.Text)]
   -- | A collection of key/value pairs following the pattern "substitution_tag":"value to substitute".
-  , _personalizationSubstitutions :: Maybe [(T.Text, T.Text)]
+  , _personalizationSubstitutions :: Maybe Object
   -- | A unix timestamp allowing you to specify when you want your email to be delivered.
   --   Scheduling more than 72 hours in advance is forbidden.
   , _personalizationSendAt        :: Maybe Int

--- a/src/Network/SendGridV3/JSON.hs
+++ b/src/Network/SendGridV3/JSON.hs
@@ -1,0 +1,7 @@
+module Network.SendGridV3.JSON where
+
+import           Data.Aeson                               ( camelTo2 )
+
+-- | Format a prefixed record field for SendGrid API consumption
+unPrefix :: String -> String -> String
+unPrefix prefix = camelTo2 '_' . drop (length prefix)

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -1,48 +1,61 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-import Data.List.NonEmpty (fromList)
-import Data.Text as T
-import Network.SendGridV3.Api
-import System.Environment
-import Test.Tasty
-import Test.Tasty.HUnit
-import Control.Lens ((^.))
-import Network.Wreq
+import           Control.Lens                             ( (^.) )
+import           Data.List.NonEmpty                       ( fromList )
+import           Data.Text                     as T
+import           Network.SendGridV3.Api
+import           Network.Wreq
+import           System.Environment
+import           Test.Tasty
+import           Test.Tasty.HUnit
 
 testMail :: MailAddress -> Mail () ()
-testMail addr =
-  mail [personalization (fromList [addr])] addr "Mail Subject" (fromList [mailContentText "Test Content"])
+testMail addr = mail [personalization (fromList [addr])]
+                     addr
+                     "Mail Subject"
+                     (fromList [mailContentText "Test Content"])
 
 main :: IO ()
 main = do
   sendgridKey  <- getSendGridKey
   testMailAddr <- getTestEmailAddress
-  defaultMain $ testGroup "SendGrid v3 API"
-    [
-      testCase "Send email simple" $ do
-        eResponse <- sendMail sendgridKey (testMail testMailAddr)
-        case eResponse of
-          Left err -> error "Failed to send simple email"
-          Right r -> r ^. responseStatus . statusCode @?= 202
+  defaultMain $ testGroup
+    "SendGrid v3 API"
+    [ testCase "Send email simple" $ do
+      eResponse <- sendMail sendgridKey (testMail testMailAddr)
+      case eResponse of
+        Left  err -> error "Failed to send simple email"
+        Right r   -> r ^. responseStatus . statusCode @?= 202
     , testCase "Send email with opts" $ do
-        eResponse <- sendMail sendgridKey ((testMail testMailAddr) { _mailSendAt = Just 1516468000 })
-        case eResponse of
-          Left err -> error "Failed to send email with opts"
-          Right r -> r ^. responseStatus . statusCode @?= 202
+      eResponse <- sendMail
+        sendgridKey
+        ((testMail testMailAddr) { _mailSendAt = Just 1516468000 })
+      case eResponse of
+        Left  err -> error "Failed to send email with opts"
+        Right r   -> r ^. responseStatus . statusCode @?= 202
+    , testCase "Send an email payload with categories correctly" $ do
+      let email =
+            (testMail testMailAddr) { _mailCategories = Just ["fake-category"] }
+      eResponse <- sendMail sendgridKey email
+      case eResponse of
+        Left  err -> error "Failed to send email with opts"
+        Right r   -> r ^. responseStatus . statusCode @?= 202
     ]
 
 getSendGridKey :: IO ApiKey
 getSendGridKey = do
   envKey <- lookupEnv "SENDGRID_API_KEY"
   case envKey of
-    Nothing -> error
-      "Please supply a Sendgrid api key for testing via the ENV var `SENDGRID_API_KEY`"
+    Nothing ->
+      error
+        "Please supply a Sendgrid api key for testing via the ENV var `SENDGRID_API_KEY`"
     Just k -> return $ ApiKey $ T.pack k
 
 getTestEmailAddress :: IO MailAddress
 getTestEmailAddress = do
   envAddr <- lookupEnv "SENDGRID_TEST_MAIL"
   case envAddr of
-    Nothing -> error
-      "Please supply an email address for testing via the ENV var `SENDGRID_TEST_MAIL`"
+    Nothing ->
+      error
+        "Please supply an email address for testing via the ENV var `SENDGRID_TEST_MAIL`"
     Just a -> return $ MailAddress (T.pack a) "John Doe"


### PR DESCRIPTION
SendGrid's API expects lower, snake-cased keys in its objects. This data is currently being serialized as upper, camel-cased keys. This fixes that and adds a new test to exercise a previously failing case.

Additionally, personalizations must have omitted Nothing fields, else they are not accepted by SendGrid. Also, `substitutions` should not be serialized as a list, but an Object.