### PR TITLE
Make MailContent nullable

### DIFF
--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -2,7 +2,7 @@
 -- documentation, see http://haskell.org/cabal/users-guide/
 
 name:                sendgrid-v3
-version:             0.2.2.1
+version:             0.3.0.0
 synopsis:            Sendgrid v3 API library
 description:         SendGrid v3 Mail API client
 homepage:            https://github.com/marcelbuesing/sendgrid-v3

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -13,7 +13,7 @@ testMail :: MailAddress -> Mail () ()
 testMail addr = mail [personalization (fromList [addr])]
                      addr
                      "Mail Subject"
-                     (fromList [mailContentText "Test Content"])
+                     (Just $ fromList [mailContentText "Test Content"])
 
 main :: IO ()
 main = do


### PR DESCRIPTION
It is allowed to send a SendGrid email with nullable MailContent,
providing only a TemplateId along with substitutions or dynamic template
data. This commit allows that workflow.

An autoformatting pass has also been run, and the major version has been bumped since the API has changed.