### PR TITLE
fix docs: ensure env vars are colllated

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,6 @@ main = do
 # Test Setup
 ```
 echo "export SENDGRID_API_KEY='SG.YOURKEY'" > sendgrid.env
-echo "export SENDGRID_TEST_MAIL='target.email.address@doe.com' > sendgrid.env
+echo "export SENDGRID_TEST_MAIL='target.email.address@doe.com' >> sendgrid.env
 source ./sendgrid.env
 ```


### PR DESCRIPTION
the documentation uses echo and shell redir to generate environmental vars to run the app. But the second line throws away the first. use >> instead to append