### PR TITLE
provide headers as an object, not array

### DIFF
--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -29,6 +29,7 @@ library
   -- other-extensions:
   build-depends:       aeson >= 1.3.0
                      , base >=4.8 && < 4.15
+                     , containers
                      , lens >= 4.13
                      , semigroups >= 0.18
                      , text >= 1.2

--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -356,6 +356,8 @@ data Mail a b = Mail
   , _mailFrom             :: MailAddress
   -- | Address details of the person to whom you are sending an email.
   , _mailReplyTo          :: Maybe MailAddress
+  -- | Address details of the people to whom you are sending an email.
+  , _mailReplyToList      :: Maybe (NonEmpty MailAddress)
   -- | The subject of your email.
   , _mailSubject          :: T.Text
   -- | An array in which you may specify the content of your email.
@@ -414,6 +416,7 @@ mail personalizations from subject mContent = Mail
   { _mailPersonalizations = personalizations
   , _mailFrom             = from
   , _mailReplyTo          = Nothing
+  , _mailReplyToList      = Nothing
   , _mailSubject          = subject
   , _mailContent          = mContent
   , _mailAttachments      = Nothing

--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -43,6 +43,7 @@ import           Data.Aeson.TH
 import           Data.ByteString.Lazy                     ( ByteString )
 import           Data.Char                                ( toLower )
 import           Data.List.NonEmpty                       ( NonEmpty )
+import qualified Data.Map                      as Map
 import           Data.Semigroup                           ( (<>) )
 import qualified Data.Text                     as T
 import           Data.Text.Encoding
@@ -103,7 +104,7 @@ data Personalization = Personalization
   -- | The subject of your email.
   , _personalizationSubject             :: Maybe T.Text
   -- | A collection of JSON key/value pairs allowing you to specify specific handling instructions for your email.
-  , _personalizationHeaders             :: Maybe [(T.Text, T.Text)]
+  , _personalizationHeaders             :: Maybe (Map.Map T.Text T.Text)
   -- | A collection of key/value pairs following the pattern "substitution_tag":"value to substitute".
   , _personalizationSubstitutions       :: Maybe Object
   -- | A unix timestamp allowing you to specify when you want your email to be delivered.
@@ -371,7 +372,7 @@ data Mail a b = Mail
   -- | An object containing key/value pairs of header names and the value to substitute for them.
   --   You must ensure these are properly encoded if they contain unicode characters.
   --   Must not be one of the reserved headers.
-  , _mailHeaders          :: Maybe [(T.Text, T.Text)]
+  , _mailHeaders          :: Maybe (Map.Map T.Text T.Text)
   -- | An array of category names for this message. Each category name may not exceed 255 characters.
   , _mailCategories       :: Maybe [T.Text]
   -- | Values that are specific to the entire send that will be carried along with

--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -62,7 +62,7 @@ data MailAddress = MailAddress
   { -- | EmailAddress e.g. john@doe.com
     _mailAddressEmail :: T.Text
     -- | The name of the person to whom you are sending an email. E.g. "John Doe"
-  , _mailAddressName  :: T.Text
+  , _mailAddressName  :: Maybe T.Text
   } deriving (Show, Eq)
 
 $(deriveToJSON (defaultOptions


### PR DESCRIPTION
The current release did not work as-is because headers are encoded arrays. I decided to modify the datatype declarations to avoid complicating the implementation. Hopefully its breakage is small because it hadn't been noticed so far

cf. https://docs.sendgrid.com/api-reference/mail-send/mail-send

