### PR TITLE
make the _mailAddressName field Text again; toJSON omits it if it's empty

### DIFF
--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -62,12 +62,14 @@ data MailAddress = MailAddress
   { -- | EmailAddress e.g. john@doe.com
     _mailAddressEmail :: T.Text
     -- | The name of the person to whom you are sending an email. E.g. "John Doe"
-  , _mailAddressName  :: Maybe T.Text
+  , _mailAddressName  :: T.Text
   } deriving (Show, Eq)
 
-$(deriveToJSON (defaultOptions
-              { fieldLabelModifier = unPrefix "_mailAddress"
-              , constructorTagModifier = map toLower }) ''MailAddress)
+instance ToJSON MailAddress where
+  toJSON (MailAddress email "") = object ["email" .= email]
+  toJSON (MailAddress email name) = object ["email" .= email, "name" .= name]
+  toEncoding (MailAddress email "") = pairs $ "email" .= email
+  toEncoding (MailAddress email name) = pairs $ "email" .= email <> "name" .= name
 
 data MailContent = MailContent
   { -- | The mime type of the content you are including in your email. For example, “text/plain” or “text/html”.

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -58,4 +58,4 @@ getTestEmailAddress = do
     Nothing ->
       error
         "Please supply an email address for testing via the ENV var `SENDGRID_TEST_MAIL`"
-    Just a -> return $ MailAddress (T.pack a) (Just "John Doe")
+    Just a -> return $ MailAddress (T.pack a) "John Doe"


### PR DESCRIPTION
Reverts a part of #22 to reduce API breakage