### PR TITLE
Skip running tests in CI if API keys are not set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         cabal build all
 
     - name: Test
+      if: ${{ env.SENDGRID_API_KEY != '' && env.SENDGRID_TEST_MAIL != '' }}
       run: |
         cabal test all
 


### PR DESCRIPTION
- This should let the CI pass on Github