### PR TITLE
Build with GHC 9.4.4 (base 4.17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
           - "8.10.7"
           - "9.0.2"
           - "9.2.3"
+          - "9.4.4"
         # exclude:
         #   - os: macOS-latest
         #     ghc: 8.8.4
@@ -93,6 +94,7 @@ jobs:
           - "8.10.7"
           - "9.0.2"
           - "9.2.3"
+          - "9.4.4"
 
     steps:
     - uses: actions/checkout@v2

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Revision history for sendgrid-v3
 
+## Unreleased
+- Niclas Åhdén: Build with GHC 9.4.4 (#29) (d93fa06)
+
 ## 1.0.0.0 -- 2022-06-27
 
 - Aditya Manthramurthy: Skip running tests in CI if API keys are not set (#27) (565d5a1)

--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -19,6 +19,7 @@ tested-with:
   GHC ==8.10.7
    || ==9.0.2
    || ==9.2.3
+   || ==9.4.4
 source-repository head
   type:              git
   location:          https://github.com/marcelbuesing/sendgrid-v3
@@ -29,7 +30,7 @@ library
   -- other-extensions:
   build-depends:       aeson >= 1.3.0
                      , containers
-                     , base >=4.8 && < 4.17
+                     , base >=4.8 && < 4.18
                      , lens >= 4.13
                      , semigroups >= 0.18
                      , text >= 1.2


### PR DESCRIPTION
We're using this fork in production at the moment and it's working well with 9.4.4.

I'm happy to change the bounds to `base >=4.8 && < 5` but went with `< 4.18` as the previous bounds were conservative. Let me know if you'd like me to change that.

Thank you for this package!