### PR TITLE
Fix Extended Master Secret Error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ A library for accessing the [v3 SendGrid API](https://sendgrid.com/docs/API_Refe
 {-# LANGUAGE OverloadedStrings #-}
 
 import Data.List.NonEmpty (fromList)
+import Data.Text (Text)
 import Network.SendGridV3.Api
 import Control.Lens ((^.))
 import Network.Wreq (responseStatus, statusCode)
 
-sendGridApiKey :: ApiKey
-sendGridApiKey = ApiKey "SG..."
+sendGridApiKey :: Text
+sendGridApiKey = "SG..."
 
 testMail :: Mail () ()
 testMail =
@@ -24,8 +25,10 @@ testMail =
 
 main :: IO ()
 main = do
+  sendgridSettings <- mkSendGridSettings sendGridApiKey
+
   -- Send an email, overriding options as needed
-  eResponse <- sendMail sendGridApiKey (testMail { _mailSendAt = Just 1516468000 })
+  eResponse <- sendMail sendgridSettings (testMail { _mailSendAt = Just 1516468000 })
   case eResponse of
     Left httpException -> error $ show httpException
     Right response -> print (response ^. responseStatus . statusCode)

--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -39,7 +39,7 @@ library
                      , http-client >= 0.5
                      , http-client-tls >= 0.3
                      , crypton-connection >= 0.3
-                     , tls >= 2.0
+                     , tls >= 1.8
                      , network-simple-tls >= 0.4
                      , bytestring >= 0.10.8
   hs-source-dirs:      src

--- a/sendgrid-v3.cabal
+++ b/sendgrid-v3.cabal
@@ -37,6 +37,10 @@ library
                      , text >= 1.2
                      , wreq >= 0.5
                      , http-client >= 0.5
+                     , http-client-tls >= 0.3
+                     , crypton-connection >= 0.3
+                     , tls >= 2.0
+                     , network-simple-tls >= 0.4
                      , bytestring >= 0.10.8
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Network/SendGridV3/Api.hs
+++ b/src/Network/SendGridV3/Api.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE CPP #-}
 
 -- | Module that implements the Mail API of SendGrid v3.
 --   https://sendgrid.com/docs/API_Reference/api_v3.html
@@ -85,7 +86,12 @@ mkSendGridSettings apiKey = do
   -- this overrides that setting and restores it to its original value: allow
   --
   -- git-annex has a simular issue: https://git-annex.branchable.com/bugs/tls__58___peer_does_not_support_Extended_Main_Secret/
-  let supported = (clientSupported clientParams) { supportedExtendedMainSecret = AllowEMS }
+  let 
+#if MIN_VERSION_tls(2,0,0) 
+      supported = (clientSupported clientParams) { supportedExtendedMainSecret = AllowEMS }
+#else
+      supported = (clientSupported clientParams) { supportedExtendedMasterSec = AllowEMS }
+#endif
       clientParams' = clientParams {clientSupported = supported}
       tlsManagerSettings = mkManagerSettings (TLSSettings clientParams') Nothing
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,7 +15,7 @@
 # resolver:
 #  name: custom-snapshot
 #  location: "./custom-snapshot.yaml"
-resolver: lts-14.27
+resolver: lts-22.19
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -39,8 +39,8 @@ packages:
 - .
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: []
-
+extra-deps:
+  - network-simple-tls-0.4.2@sha256:880d4e1f87e6984d6e8c912b00a599d03174ec6741b379f006f78c0711343b63,1422
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -17,7 +17,7 @@ testMail addr = mail [personalization (fromList [addr])]
 
 main :: IO ()
 main = do
-  sendgridKey  <- getSendGridKey
+  sendgridKey  <- getSendGridSettings
   testMailAddr <- getTestEmailAddress
   defaultMain $ testGroup
     "SendGrid v3 API"
@@ -42,14 +42,14 @@ main = do
         Right r   -> r ^. responseStatus . statusCode @?= 202
     ]
 
-getSendGridKey :: IO ApiKey
-getSendGridKey = do
+getSendGridSettings :: IO SendGridSettings
+getSendGridSettings = do
   envKey <- lookupEnv "SENDGRID_API_KEY"
   case envKey of
     Nothing ->
       error
         "Please supply a Sendgrid api key for testing via the ENV var `SENDGRID_API_KEY`"
-    Just k -> return $ ApiKey $ T.pack k
+    Just k -> mkSendGridSettings $ T.pack k
 
 getTestEmailAddress :: IO MailAddress
 getTestEmailAddress = do

--- a/tests/test.hs
+++ b/tests/test.hs
@@ -24,21 +24,21 @@ main = do
     [ testCase "Send email simple" $ do
       eResponse <- sendMail sendgridKey (testMail testMailAddr)
       case eResponse of
-        Left  err -> error "Failed to send simple email"
+        Left  err -> assertFailure $ "Failed to send simple email: " <> show err
         Right r   -> r ^. responseStatus . statusCode @?= 202
     , testCase "Send email with opts" $ do
       eResponse <- sendMail
         sendgridKey
         ((testMail testMailAddr) { _mailSendAt = Just 1516468000 })
       case eResponse of
-        Left  err -> error "Failed to send email with opts"
+        Left  err -> assertFailure $ "Failed to send email with opts: " <> show err
         Right r   -> r ^. responseStatus . statusCode @?= 202
     , testCase "Send an email payload with categories correctly" $ do
       let email =
             (testMail testMailAddr) { _mailCategories = Just ["fake-category"] }
       eResponse <- sendMail sendgridKey email
       case eResponse of
-        Left  err -> error "Failed to send email with opts"
+        Left  err -> assertFailure $ "Failed to send email with opts: " <> show err
         Right r   -> r ^. responseStatus . statusCode @?= 202
     ]
 


### PR DESCRIPTION
The `tls` package has changed the default extended master secret policy to required, SendGrid doesn't support EMS so this breaks this package. Same issue as `git-annex`, see https://git-annex.branchable.com/bugs/tls__58___peer_does_not_support_Extended_Main_Secret/.

This PR restores the pre 2.0 tls default of allowing EMS. 

- `47030fe` doesn't change the api, just changes the EMS policy
- `ab4d031` moves the api key and http client settings to a new SendGridSettings to enable reuse of tls connections, I made it a separate commit in case this isn't wanted.